### PR TITLE
count-when

### DIFF
--- a/src/kixi/stats/core.cljc
+++ b/src/kixi/stats/core.cljc
@@ -20,6 +20,17 @@
     ([n _] (inc n))
     ([n] n)))
 
+(defn count-when
+  "Calculates the count of inputs for which `pred` returns truthy."
+  [pred]
+  (fn
+    ([] 0)
+    ([n x]
+     (if (pred x)
+       (inc n)
+       n))
+    ([n] n)))
+
 (def arithmetic-mean
   "Calculates the arithmetic mean of numeric inputs."
   (fn

--- a/test/kixi/stats/core_test.cljc
+++ b/test/kixi/stats/core_test.cljc
@@ -313,6 +313,16 @@
 (deftest count-test
   (is (zero? (transduce identity kixi/count []))))
 
+(defspec count-when-spec
+  test-opts
+  (for-all [xs (gen/vector numeric)]
+           (let [pred (kixi/somef pos?)]
+             (is (= (transduce identity (kixi/count-when pred) xs)
+                    (count (filter pred xs)))))))
+
+(deftest count-when-test
+  (is (zero? (transduce identity (kixi/count-when pos?) []))))
+
 (defspec arithmetic-mean-spec
   test-opts
   (for-all [xs (gen/vector numeric)]


### PR DESCRIPTION
Adds count when (not entirely sure sure if it's needed as the same functionality can be achieved with `(redux/with-xform stats/count (filter pred))`), but it's something I use quite often. 