### PR TITLE
Add min, max, share, and monoid

### DIFF
--- a/src/kixi/stats/core.cljc
+++ b/src/kixi/stats/core.cljc
@@ -468,7 +468,7 @@
       :total 0})
     ([{:keys [match total]}]
      (when (pos? total)
-       (/ match total)))
+       (double (/ match total))))
     ([{:keys [match total]} e]
      {:match (cond-> match
                (pred e) inc)
@@ -477,7 +477,9 @@
 (defn min
   "Like clojure.core/min, but transducer and nil-friendly."
   ([] Double/POSITIVE_INFINITY)
-  ([acc] acc)
+  ([acc]
+   (when (not= acc Double/POSITIVE_INFINITY)
+     acc))
   ([^double acc e]
    (if (nil? e)
      acc
@@ -487,7 +489,9 @@
 (defn max
   "Like clojure.core/max, but transducer and nil-friendly."
   ([] Double/NEGATIVE_INFINITY)
-  ([acc] acc)
+  ([acc]
+   (when (not= acc Double/NEGATIVE_INFINITY)
+     acc))
   ([^double acc e]
    (if (nil? e)
      acc

--- a/src/kixi/stats/core.cljc
+++ b/src/kixi/stats/core.cljc
@@ -467,7 +467,7 @@
      {:match 0
       :total 0})
     ([{:keys [match total]}]
-     (when (pos total)
+     (when (pos? total)
        (/ match total)))
     ([{:keys [match total]} e]
      {:match (cond-> match

--- a/test/kixi/stats/core_test.cljc
+++ b/test/kixi/stats/core_test.cljc
@@ -542,3 +542,15 @@
                    (repeat 8 {:v1 :b :v2 :y}))]
     (is (=ish (transduce identity (kixi/chisq-test :v1 :v2) xs)
               {:p-value 0.6903283294641935, :X-sq 0.1587301587301587, :dof 1}))))
+
+(deftest min-test
+  (is (= 1 (transduce identity kixi/min [2 1 nil 5 3 ]))))
+
+(deftest max-test
+  (is (= 5 (transduce identity kixi/min [2 1 nil 5 3]))))
+
+(deftest share-test
+  (is (=ish (transduce identity (kixi/share neg?) [1 -1 3 5]) 0.25)))
+
+(deftest monoid-test
+  (is (= :init (kixi/monoid identity :init))))

--- a/test/kixi/stats/core_test.cljc
+++ b/test/kixi/stats/core_test.cljc
@@ -544,13 +544,13 @@
               {:p-value 0.6903283294641935, :X-sq 0.1587301587301587, :dof 1}))))
 
 (deftest min-test
-  (is (= 1 (transduce identity kixi/min [2 1 nil 5 3 ]))))
+  (is (= 1.0 (transduce identity kixi/min [2 1 nil 5 3 ]))))
 
 (deftest max-test
-  (is (= 5 (transduce identity kixi/min [2 1 nil 5 3]))))
+  (is (= 5.0 (transduce identity kixi/max [2 1 nil 5 3]))))
 
 (deftest share-test
   (is (=ish (transduce identity (kixi/share neg?) [1 -1 3 5]) 0.25)))
 
 (deftest monoid-test
-  (is (= :init (kixi/monoid identity :init))))
+  (is (= :init ((kixi/monoid identity :init)))))

--- a/test/kixi/stats/core_test.cljc
+++ b/test/kixi/stats/core_test.cljc
@@ -544,10 +544,12 @@
               {:p-value 0.6903283294641935, :X-sq 0.1587301587301587, :dof 1}))))
 
 (deftest min-test
-  (is (= 1.0 (transduce identity kixi/min [2 1 nil 5 3 ]))))
+  (is (= 1.0 (transduce identity kixi/min [2 1 nil 5 3 ])))
+  (is (nil? (transduce identity kixi/min []))))
 
 (deftest max-test
-  (is (= 5.0 (transduce identity kixi/max [2 1 nil 5 3]))))
+  (is (= 5.0 (transduce identity kixi/max [2 1 nil 5 3])))
+  (is (nil? (transduce identity kixi/max []))))
 
 (deftest share-test
   (is (=ish (transduce identity (kixi/share neg?) [1 -1 3 5]) 0.25)))


### PR DESCRIPTION
This adds a couple more reducing functions that I always end up writing (`min`, `max`, `share`), and a version of `monoid` that works with transducers.

I'm not entirely sure it is correct for `min` to return `Double/POSITIVE_INFINITY`. It is an identity wrt to min, but can mess up other math operations if you don't expect it (or just look weird). An alternative would be to return nil, which is consistent with behaviour elsewhere when working with empty datasets.