### PR TITLE
Fixed the mean function

### DIFF
--- a/src/kixi/stats/core.cljc
+++ b/src/kixi/stats/core.cljc
@@ -85,8 +85,8 @@
 (def arithmetic-mean
   "Calculates the arithmetic mean of numeric inputs."
   (fn
-    ([] [0.0 0.0])
-    ([[^double s ^double c :as acc] e]
+    ([] [0.0 0])
+    ([[^double s ^long c :as acc] e]
      (if (nil? e)
        acc
        (let [e (double e)]

--- a/src/kixi/stats/core.cljc
+++ b/src/kixi/stats/core.cljc
@@ -130,8 +130,8 @@
 (def variance-s
   "Estimates an unbiased variance of numeric inputs."
   (fn
-    ([] [0.0 0.0 0.0])
-    ([[^double c ^double m ^double ss :as acc] e]
+    ([] [0 0.0 0.0])
+    ([[^long c ^double m ^double ss :as acc] e]
      (if (nil? e)
        acc
        (let [e  (double e)


### PR DESCRIPTION
The count `c` parameter is initialized as a floating number and hinted as a `double` while it is used as a natural number to count. It is clearly a bug as a floating number will makes the `inc` operation idempotent once it reaches a certain value.

This is what I get on the JVM:
```clojure
(defn foo [x]
  (let [y (inc x)]
    [x y (= x y)]))

(foo 9007199254740991.0)
=> [9.007199254740991E15 9.007199254740992E15 false]

; `inc` can't work on floating values as high as this one.
(foo 9007199254740992.0)
=> [9.007199254740992E15 9.007199254740992E15 true]

; long values are still fine
(foo 9007199254740992)
=> [9007199254740992 9007199254740993 false]

; long values can go much higher
(foo 9223372036854775806)
=> [9223372036854775806 9223372036854775807 false]

; long values will throw an exception once they can't be incremented while floating values will silently be wrong.
(inc Long/MAX_VALUE)
=> Syntax error (ArithmeticException)
=> integer overflow
```