### PR TITLE
Named distribution parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.5.1 (2019-07-27)
+
+* **BREAKING CHANGE** All distributions now expect named rather than positional args
+* The normal distribution can now be paramaterised with `:location` & `:scale` to align more closely with other distributions
+* The categorical distribution now expects a map of {category-name => probability}, rather than separate category and probability vectors
+
 ## 0.5.0 (2019-01-05)
 
 * **BREAKING CHANGE** Protocol I prefix is replaced with P

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.5.1 (2019-07-27)
+## 0.5.1 (2019-07-30)
 
 * **BREAKING CHANGE** All distributions now expect named rather than positional args
 * The normal distribution can now be paramaterised with `:location` & `:scale` to align more closely with other distributions

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ The Bernoulli, binomial and categorical distributions are discrete, so samples c
 ```clojure
 (require '[kixi.stats.distribution :refer [sample-summary bernoulli]])
 
-(sample-summary 1000 (bernoulli 0.3))
+(sample-summary 1000 (bernoulli {:p 0.3}))
 
 ;;=> {true 296, false 704}
 ```
@@ -245,11 +245,11 @@ The sampling functions `draw`, `sample` and `sample-summary` are all designed to
 ```clojure
 (require '[kixi.stats.distribution :refer [uniform]])
 
-(draw (uniform 0 1) {:seed 42})
+(draw (uniform {:a 0 :b 1}) {:seed 42})
 
 ;;=> 0.7415648787718233
 
-(draw (uniform 0 1) {:seed 42})
+(draw (uniform {:a 0 :b 1}) {:seed 42})
 
 ;;=> 0.7415648787718233
 ```

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ The Bernoulli, binomial and categorical distributions are discrete, so samples c
 ;;=> {true 296, false 704}
 ```
 
-This is equivalent to `(frequencies (sample 1000 (bernoulli 0.3)))`, but where possible `sample-summary` uses optimisations to avoid reifying and aggregating a large intermediate sample, and should be preferred. When `sample-summary` doesn't return a value for a particular variate, that value should be assumed zero.
+This is equivalent to `(frequencies (sample 1000 (bernoulli {:p 0.3})))`, but where possible `sample-summary` uses optimisations to avoid reifying and aggregating a large intermediate sample, and should be preferred. When `sample-summary` doesn't return a value for a particular variate, that value should be assumed zero.
 
 **Deterministic sampling**
 

--- a/src/kixi/stats/distribution.cljc
+++ b/src/kixi/stats/distribution.cljc
@@ -579,9 +579,9 @@
 
 (defn gamma
   "Returns a gamma distribution.
-  Params: {:shape ∈ ℝ, :scale ∈ ℝ}"
-  [{:keys [shape scale] :or {shape 1.0 scale 1.0}}]
-  (->Gamma shape scale))
+  Params: {:shape ∈ ℝ, :scale ∈ ℝ} or {:shape ∈ ℝ, :rate ∈ ℝ}"
+  [{:keys [shape scale rate] :or {shape 1.0}}]
+  (->Gamma shape (or scale (/ 1.0 rate))))
 
 (defn beta
   "Returns a beta distribution.

--- a/src/kixi/stats/distribution.cljc
+++ b/src/kixi/stats/distribution.cljc
@@ -543,20 +543,20 @@
 
 (defn uniform
   "Returns a uniform distribution.
-  Params: a ∈ ℝ, b ∈ ℝ"
-  [a b]
+  Params: {:a ∈ ℝ, :b ∈ ℝ}"
+  [{:keys [a b]}]
   (->Uniform a b))
 
 (defn exponential
   "Returns an exponential distribution.
-  Params: rate ∈ ℝ > 0"
-  [rate]
+  Params: {:rate ∈ ℝ > 0}"
+  [{:keys [rate]}]
   (->Exponential rate))
 
 (defn bernoulli
   "Returns a Bernoulli distribution.
-  Params: p ∈ [0 1]"
-  [p]
+  Params: {:p ∈ [0 1]}"
+  [{:keys [p]}]
   (->Bernoulli p))
 
 (defn binomial
@@ -567,15 +567,15 @@
 
 (defn normal
   "Returns a normal distribution.
-  Params: {:mu ∈ ℝ, :sd ∈ ℝ}"
-  [{:keys [mu sd]}]
-  (->Normal mu sd))
+  Params: {:location ∈ ℝ, :scale ∈ ℝ}"
+  [{:keys [location scale mu sd]}]
+  (->Normal (or location mu) (or scale sd)))
 
 (defn t
   "Returns a t distribution.
-  Params: dof ∈ ℕ > 0"
-  [dof]
-  (->T dof))
+  Params: {:v ∈ ℕ > 0}"
+  [{:keys [v]}]
+  (->T v))
 
 (defn gamma
   "Returns a gamma distribution.
@@ -591,8 +591,8 @@
 
 (defn beta-binomial
   "Returns a beta distribution.
-  Params: n ∈ ℕ, {:alpha ∈ ℝ, :beta ∈ ℝ}"
-  [n {:keys [alpha beta] :or {alpha 1.0 beta 1.0}}]
+  Params: {:n ∈ ℕ > 0, :alpha ∈ ℝ > 0, :beta ∈ ℝ > 0}"
+  [{:keys [n alpha beta] :or {alpha 1.0 beta 1.0}}]
   (->BetaBinomial n alpha beta))
 
 (defn weibull
@@ -603,50 +603,48 @@
 
 (defn chi-squared
   "Returns a chi-squared distribution.
-  Params: k ∈ ℕ > 0"
-  [k]
+  Params: {:k ∈ ℕ > 0}"
+  [{:keys [k]}]
   (->ChiSquared k))
 
 (defn f
   "Returns an F distribution.
-  Params: d1 ∈ ℕ > 0, d2 ∈ ℕ > 0"
-  [d1 d2]
+  Params: {:d1 ∈ ℕ > 0, :d2 ∈ ℕ > 0}"
+  [{:keys [d1 d2]}]
   (->F d1 d2))
 
 (defn poisson
   "Returns a Poisson distribution.
-  Params: lambda ∈ ℝ > 0"
-  [lambda]
+  Params: {:lambda ∈ ℝ > 0}"
+  [{:keys [lambda]}]
   (->Poisson lambda))
 
 (defn categorical
   "Returns a categorical distribution.
-  Params: [k1, ..., kn], [p1, ..., pn]
-  where k1...kn are the categories
-  and p1...pn are probabilities.
+  Params: {[category] [probability], ...}
   Probabilities should be >= 0 and sum to 1"
-  [ks ps]
-  (->Categorical ks ps))
+  [category-probs]
+  (let [[ks ps] (apply map vector kp)]
+    (->Categorical ks ps)))
 
 (defn multinomial
   "Returns a multinomial distribution.
-  Params: n ∈ ℕ > 0, [p1, ..., pn]
-  where p1...pn are probabilities.
+  Params: {:n ∈ ℕ > 0, :probs [ℝ >= 0, ...]}
   Probabilities should be >= 0 and sum to 1"
-  [n ps]
-  (->Multinomial n ps))
+  [{:keys [n probs]}]
+  (->Multinomial n probs))
 
 (defn dirichlet
   "Returns a Dirichlet distribution.
-  Params: [a1...an] ∈ ℝ >= 0"
-  [as]
-  (->Dirichlet as))
+  Params: {:alphas [ℝ >= 0, ...]}"
+  [{:keys [alphas]}]
+  (->Dirichlet alphas))
 
 (defn dirichlet-multinomial
   "Returns a Dirichlet-multinomial distribution.
-  Params: n ∈ ℕ, [a1...an] ∈ ℝ >= 0"
-  [n as]
-  (->DirichletMultinomial n as))
+  Params: {:n ∈ ℕ, :alphas [ℝ >= 0, ...]}"
+  [{:keys [n alphas]}]
+  (->DirichletMultinomial n alphas))
 
 (defn draw
   "Returns a single variate from the distribution.

--- a/src/kixi/stats/estimate.cljc
+++ b/src/kixi/stats/estimate.cljc
@@ -30,7 +30,7 @@
         y-hat (p/measure regression x)
         se (regression-standard-error sum-squares x)
         df (- n 2)
-        t-crit (d/critical-value (d/t df) alpha)
+        t-crit (d/critical-value (d/t {:v df}) alpha)
         err (* t-crit se)]
     (reify p/PInterval
       (lower [_] (- y-hat err))
@@ -50,7 +50,7 @@
         y-hat (p/measure regression x)
         se (regression-prediction-standard-error sum-squares x)
         df (- n 2)
-        t-crit (d/critical-value (d/t df) alpha)
+        t-crit (d/critical-value (d/t {:v df}) alpha)
         err (* t-crit se)]
     (reify p/PInterval
       (lower [_] (- y-hat err))

--- a/src/kixi/stats/test.cljc
+++ b/src/kixi/stats/test.cljc
@@ -49,7 +49,7 @@
                                   e (/ (apply * counts) total)]
                               (+ acc (/ (sq (- e cell)) e))))
                           0))]
-    (test-result stat (d/chi-squared dof) :>)))
+    (test-result stat (d/chi-squared {:k dof}) :>)))
 
 (defn simple-z-test
   "Calculates the z-test of statistical significance for a sample mean.
@@ -61,7 +61,7 @@
   [{:keys [mu sd]} {:keys [mean n]}]
   (when (and (pos? n) (pos? sd))
     (let [z (double (/ (- mean mu) (/ sd (sqrt n))))]
-      (test-result z (d/normal {:mu 0.0 :sd 1.0})))))
+      (test-result z (d/normal {:location 0.0 :scale 1.0})))))
 
 (defn z-test
   "Calculates the z-test of statistical significance between two sample means.
@@ -76,7 +76,7 @@
                (pos? sd-xy)
                (double (/ (- mean-x mean-y) sd-xy)))]
     (when z
-      (test-result z (d/normal {:mu 0.0 :sd 1.0})))))
+      (test-result z (d/normal {:location 0.0 :scale 1.0})))))
 
 (defn t-test
   "Calculates Welch's unequal variances t-test of statistical significance.
@@ -95,7 +95,7 @@
                     (+ (/ (pow sd-a 4) (* n-a n-a (dec n-a)))
                        (/ (pow sd-b 4) (* n-b n-b (dec n-b))))))]
     (when (and t dof)
-      (test-result t (d/t dof)))))
+      (test-result t (d/t {:v dof})))))
  
 (defn simple-t-test
   "Calculates the t-test of statistical significance for a sample mean.
@@ -110,4 +110,4 @@
                (double (/ (- mean mu)
                           (/ sd (sqrt n)))))]
     (when (and t (pos? dof))
-      (test-result t (d/t dof)))))
+      (test-result t (d/t {:v dof})))))

--- a/test/kixi/stats/distribution_test.cljc
+++ b/test/kixi/stats/distribution_test.cljc
@@ -116,32 +116,32 @@
             d gen/s-pos-int
             n gen/nat
             [ks ps] gen-categories]
-    (is (= (sut/draw (sut/uniform a b) {:seed seed})
-           (sut/draw (sut/uniform a b) {:seed seed})))
-    (is (= (sut/draw (sut/exponential r) {:seed seed})
-           (sut/draw (sut/exponential r) {:seed seed})))
-    (is (= (sut/draw (sut/bernoulli p) {:seed seed})
-           (sut/draw (sut/bernoulli p) {:seed seed})))
+    (is (= (sut/draw (sut/uniform {:a a :b b}) {:seed seed})
+           (sut/draw (sut/uniform {:a a :b b}) {:seed seed})))
+    (is (= (sut/draw (sut/exponential {:rate r}) {:seed seed})
+           (sut/draw (sut/exponential {:rate r}) {:seed seed})))
+    (is (= (sut/draw (sut/bernoulli {:p p}) {:seed seed})
+           (sut/draw (sut/bernoulli {:p p}) {:seed seed})))
     (is (= (sut/draw (sut/binomial {:n n :p p}) {:seed seed})
            (sut/draw (sut/binomial {:n n :p p}) {:seed seed})))
-    (is (= (sut/draw (sut/normal {:mu a :sd b}) {:seed seed})
-           (sut/draw (sut/normal {:mu a :sd b}) {:seed seed})))
-    (is (= (sut/draw (sut/t d) {:seed seed})
-           (sut/draw (sut/t d) {:seed seed})))
+    (is (= (sut/draw (sut/normal {:location a :scale b}) {:seed seed})
+           (sut/draw (sut/normal {:location a :scale b}) {:seed seed})))
+    (is (= (sut/draw (sut/t {:v d}) {:seed seed})
+           (sut/draw (sut/t {:v d}) {:seed seed})))
     (is (= (sut/draw (sut/gamma {:shape s :scale (/ 0.5 r)}) {:seed seed})
            (sut/draw (sut/gamma {:shape s :scale (/ 0.5 r)}) {:seed seed})))
     (is (= (sut/draw (sut/beta {:alpha alpha :beta beta}) {:seed seed})
            (sut/draw (sut/beta {:alpha alpha :beta beta}) {:seed seed})))
     (is (= (sut/draw (sut/weibull {:shape alpha :scale beta}) {:seed seed})
            (sut/draw (sut/weibull {:shape alpha :scale beta}) {:seed seed})))
-    (is (= (sut/draw (sut/chi-squared k) {:seed seed})
-           (sut/draw (sut/chi-squared k) {:seed seed})))
-    (is (= (sut/draw (sut/f k d) {:seed seed})
-           (sut/draw (sut/f k d) {:seed seed})))
-    (is (= (sut/draw (sut/poisson alpha) {:seed seed})
-           (sut/draw (sut/poisson alpha) {:seed seed})))
-    (is (= (sut/draw (sut/categorical ks ps) {:seed seed})
-           (sut/draw (sut/categorical ks ps) {:seed seed})))))
+    (is (= (sut/draw (sut/chi-squared {:k k}) {:seed seed})
+           (sut/draw (sut/chi-squared {:k k}) {:seed seed})))
+    (is (= (sut/draw (sut/f {:d1 k :d2 d}) {:seed seed})
+           (sut/draw (sut/f {:d1 k :d2 d}) {:seed seed})))
+    (is (= (sut/draw (sut/poisson {:lambda alpha}) {:seed seed})
+           (sut/draw (sut/poisson {:lambda alpha}) {:seed seed})))
+    (is (= (sut/draw (sut/categorical (zipmap ks ps)) {:seed seed})
+           (sut/draw (sut/categorical (zipmap ks ps)) {:seed seed})))))
 
 (defspec seeded-samples-are-deterministic
   test-opts
@@ -157,32 +157,32 @@
             d gen/s-pos-int
             n gen/nat
             [ks ps] gen-categories]
-    (is (= (sut/sample n (sut/uniform a b) {:seed seed})
-           (sut/sample n (sut/uniform a b) {:seed seed})))
-    (is (= (sut/sample n (sut/exponential r) {:seed seed})
-           (sut/sample n (sut/exponential r) {:seed seed})))
-    (is (= (sut/sample n (sut/bernoulli p) {:seed seed})
-           (sut/sample n (sut/bernoulli p) {:seed seed})))
+    (is (= (sut/sample n (sut/uniform {:a a :b b}) {:seed seed})
+           (sut/sample n (sut/uniform {:a a :b b}) {:seed seed})))
+    (is (= (sut/sample n (sut/exponential {:rate r}) {:seed seed})
+           (sut/sample n (sut/exponential {:rate r}) {:seed seed})))
+    (is (= (sut/sample n (sut/bernoulli {:p p}) {:seed seed})
+           (sut/sample n (sut/bernoulli {:p p}) {:seed seed})))
     (is (= (sut/sample n (sut/binomial {:n n :p p}) {:seed seed})
            (sut/sample n (sut/binomial {:n n :p p}) {:seed seed})))
-    (is (= (sut/sample n (sut/normal {:mu a :sd b}) {:seed seed})
-           (sut/sample n (sut/normal {:mu a :sd b}) {:seed seed})))
-    (is (= (sut/sample n (sut/t d) {:seed seed})
-           (sut/sample n (sut/t d) {:seed seed})))
+    (is (= (sut/sample n (sut/normal {:location a :scale b}) {:seed seed})
+           (sut/sample n (sut/normal {:location a :scale b}) {:seed seed})))
+    (is (= (sut/sample n (sut/t {:v d}) {:seed seed})
+           (sut/sample n (sut/t {:v d}) {:seed seed})))
     (is (= (sut/sample n (sut/gamma {:shape s :scale (/ 0.5 r)}) {:seed seed})
            (sut/sample n (sut/gamma {:shape s :scale (/ 0.5 r)}) {:seed seed})))
     (is (= (sut/sample n (sut/beta {:alpha alpha :beta beta}) {:seed seed})
            (sut/sample n (sut/beta {:alpha alpha :beta beta}) {:seed seed})))
     (is (= (sut/sample n (sut/weibull {:shape alpha :scale beta}) {:seed seed})
            (sut/sample n (sut/weibull {:shape alpha :scale beta}) {:seed seed})))
-    (is (= (sut/sample n (sut/chi-squared k) {:seed seed})
-           (sut/sample n (sut/chi-squared k) {:seed seed})))
-    (is (= (sut/sample n (sut/f k d) {:seed seed})
-           (sut/sample n (sut/f k d) {:seed seed})))
-    (is (= (sut/sample n (sut/poisson alpha) {:seed seed})
-           (sut/sample n (sut/poisson alpha) {:seed seed})))
-    (is (= (sut/sample n (sut/categorical ks ps) {:seed seed})
-           (sut/sample n (sut/categorical ks ps) {:seed seed})))))
+    (is (= (sut/sample n (sut/chi-squared {:k k}) {:seed seed})
+           (sut/sample n (sut/chi-squared {:k k}) {:seed seed})))
+    (is (= (sut/sample n (sut/f {:d1 k :d2 d}) {:seed seed})
+           (sut/sample n (sut/f {:d1 k :d2 d}) {:seed seed})))
+    (is (= (sut/sample n (sut/poisson {:lambda alpha}) {:seed seed})
+           (sut/sample n (sut/poisson {:lambda alpha}) {:seed seed})))
+    (is (= (sut/sample n (sut/categorical (zipmap ks ps)) {:seed seed})
+           (sut/sample n (sut/categorical (zipmap ks ps)) {:seed seed})))))
 
 (defn mean-convergence-reducer
   [mean]
@@ -248,31 +248,31 @@
             d gen-dof
             small-n gen-small-n]
     (is (converges-to-mean? (+ a (/ (- b a) 2))
-                            (sut/uniform a b)))
+                            (sut/uniform {:a a :b b})))
     (is (converges-to-mean? (/ 1 r)
-                            (sut/exponential r)))
+                            (sut/exponential {:rate r})))
     (is (converges-to-mean? (* n p)
                             (sut/binomial {:n n :p p})))
     (is (converges-to-mean? a
-                            (sut/normal {:mu a :sd r})))
+                            (sut/normal {:location a :scale (/ 1 r)})))
     (is (converges-to-mean? 0.0
-                            (sut/t d)))
+                            (sut/t {:v d})))
     (is (converges-to-mean? (/ s r)
                             (sut/gamma {:shape s :scale (/ 1 r)})))
+    (is (converges-to-mean? (/ s r)
+                            (sut/gamma {:shape s :rate r})))
     (is (converges-to-mean? (/ alpha (+ alpha beta))
                             (sut/beta {:alpha alpha :beta beta})))
     (is (converges-to-mean? (* beta (gamma (inc (/ 1 alpha))))
                             (sut/weibull {:shape alpha :scale beta})))
-    (is (converges-to-mean? (/ s r)
-                            (sut/gamma {:shape s :scale (/ 1 r)})))
     (is (converges-to-mean? k
-                            (sut/chi-squared k)))
+                            (sut/chi-squared {:k k})))
     (is (converges-to-mean? (/ d (- d 2))
-                            (sut/f k d)))
+                            (sut/f {:d1 k :d2 d})))
     (is (converges-to-mean? alpha
-                            (sut/poisson alpha)))
+                            (sut/poisson {:lambda alpha})))
     (is (converges-to-mean? (mapv #(* small-n %) ps)
-                            (sut/multinomial small-n ps)))))
+                            (sut/multinomial {:n small-n :probs ps})))))
 
 (defspec sample-summary-returns-categorical-sample-frequencies
   test-opts
@@ -280,14 +280,14 @@
             p gen-probability
             n gen/nat
             [ks ps] gen-categories]
-    (is (= (sut/sample-summary n (sut/bernoulli p) {:seed seed})
-           (->> (sut/sample n (sut/bernoulli p) {:seed seed})
+    (is (= (sut/sample-summary n (sut/bernoulli {:p p}) {:seed seed})
+           (->> (sut/sample n (sut/bernoulli {:p p}) {:seed seed})
                 (frequencies)
                 (merge {true 0 false 0}))))
-    (is (= (->> (sut/sample-summary n (sut/categorical ks ps) {:seed seed})
+    (is (= (->> (sut/sample-summary n (sut/categorical (zipmap ks ps)) {:seed seed})
                 (remove (fn [[k v]] (zero? v)))
                 (into {}))
-           (->> (sut/sample n (sut/categorical ks ps) {:seed seed})
+           (->> (sut/sample n (sut/categorical (zipmap ks ps)) {:seed seed})
                 (frequencies))))))
 
 (defspec uniform-does-not-exceed-bounds
@@ -296,21 +296,21 @@
             [a b] (->> (gen/tuple gen/int gen/int)
                        (gen/such-that (fn [[a b]] (not= a b)))
                        (gen/fmap sort))]
-    (let [draw (sut/draw (sut/uniform a b) {:seed seed})]
+    (let [draw (sut/draw (sut/uniform {:a a :b b}) {:seed seed})]
       (is (and (<= a draw) (< draw b))))))
 
 (defspec exponential-returns-positive-floats
   test-opts
   (for-all [seed gen/int
             r gen-rate]
-    (is (float? (sut/draw (sut/exponential r) {:seed seed})))
-    (is (pos? (sut/draw (sut/exponential r) {:seed seed})))))
+    (is (float? (sut/draw (sut/exponential {:rate r}) {:seed seed})))
+    (is (pos? (sut/draw (sut/exponential {:rate r}) {:seed seed})))))
 
 (defspec bournoulli-returns-boolean
   test-opts
   (for-all [seed gen/int
             p gen-probability]
-    (is (contains? #{true false} (sut/draw (sut/bernoulli p) {:seed seed})))))
+    (is (contains? #{true false} (sut/draw (sut/bernoulli {:p p}) {:seed seed})))))
 
 (defspec binomial-returns-integers
   test-opts
@@ -323,23 +323,23 @@
   test-opts
   (for-all [seed gen/int
             [ks ps] gen-categories]
-    (is (contains? (set ks) (sut/draw (sut/categorical ks ps) {:seed seed})))))
+    (is (contains? (set ks) (sut/draw (sut/categorical (zipmap ks ps)) {:seed seed})))))
 
 (defspec bernoulli-probabilities-are-well-behaved
   test-opts
   (for-all [seed gen/int]
-    (is (false? (sut/draw (sut/bernoulli 0.0) {:seed seed})))
-    (is (true? (sut/draw (sut/bernoulli 1.0) {:seed seed})))))
+    (is (false? (sut/draw (sut/bernoulli {:p 0.0}) {:seed seed})))
+    (is (true? (sut/draw (sut/bernoulli {:p 1.0}) {:seed seed})))))
 
 (defspec multinomial-sample-sums-to-n
   test-opts
   (for-all [seed gen/int
             n gen-small-n
             probs gen-probabilities]
-    (is (= n (apply + (sut/draw (sut/multinomial n probs) {:seed seed}))))))
+    (is (= n (apply + (sut/draw (sut/multinomial {:n n :probs probs}) {:seed seed}))))))
 
 (defspec dirichlet-sample-sums-to-1
   test-opts
   (for-all [seed gen/int
             as gen-alphas]
-    (is (equal 1.0 (apply + (sut/draw (sut/dirichlet as) {:seed seed})) 1e-15))))
+    (is (equal 1.0 (apply + (sut/draw (sut/dirichlet {:alphas as}) {:seed seed})) 1e-15))))


### PR DESCRIPTION
All distribution public API functions now take named rather than positional arguments. In addition to avoiding positional bugs, this decision ensures that we are more consistently able to support distributions that could be parameterised in one of several different ways.