### PR TITLE
Implement PQuantile for the Uniform distribution

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[redux "0.1.4"]
-                 [org.clojure/test.check "1.0.0"]
+                 [org.clojure/test.check "1.1.0"]
                  [org.clojure/math.combinatorics "0.1.6"]
                  [com.tdunning/t-digest "3.2"]]
   :profiles {:dev

--- a/src/kixi/stats/distribution.cljc
+++ b/src/kixi/stats/distribution.cljc
@@ -248,6 +248,19 @@
       (+ (* (rand-double rng) (- b a)) a))
     (sample-n [this n rng]
       (default-sample-n this n rng))
+    p/PQuantile
+    (cdf [this x]
+      (cond
+        (<= x a) 0.0
+        (>= x b) 1.0
+        :else
+        (/ (- x a) (- b a))))
+    (quantile [this p]
+      (cond
+        (zero? p) a
+        (= p 1.0) b
+        :else
+        (+ a (* p (- b a)))))
     #?@(:clj (clojure.lang.Seqable
               (seq [this] (sampleable->seq this)))
         :cljs (ISeqable

--- a/test/kixi/stats/distribution_test.cljc
+++ b/test/kixi/stats/distribution_test.cljc
@@ -114,13 +114,14 @@
 
 (defspec cdf-and-quantile-are-inverses
   test-opts
-  (for-all [a gen/int
+  (for-all [[a b] gen-two-ascending-ints
             r gen-rate
             s gen-shape
             p gen-probability
             alpha gen-pos-real
             k (gen/fmap inc gen/nat)
             d gen-small-n]
+    (is (=ish p (cdf-quantile (sut/uniform {:a a :b b}) p)))
     (is (=ish p (cdf-quantile (sut/normal {:location a :scale k}) p)))
     (is (=ish p (cdf-quantile (sut/log-normal {:location a :scale k}) p)))
     (is (=ish p (cdf-quantile (sut/cauchy {:location a :scale alpha}) p)))


### PR DESCRIPTION
I implemented PQuantile for Uniform.
In implementing quantile, I chose to return a for 0.0 and b for 1.0 to make quantile symmetric with cdf.

I added a cdf-and-quantile-are-inverses test for Uniform.  In implementing the test, I realized that a < b and so copied the generator you had in the uniform-does-not-exceed-bounds test and made it a helper function gen-two-ascending-ints. I did not reuse the helper function uniform-does-not-exceed-bounds so as to keep the diffs small and to not disturb existing code.  But happy to do the refactor if you're okay with it.

I also added an assert for a < b. However that caused other tests to fail.  So, for now I have commented out the assert. After investigation, I found that several of the tests using the Uniform distribution do not guarantee that a < b. I am happy to fix those if you are okay with it.

During the investigation, I also noticed that in some tests for Normal, the scale parameter could be negative.  Is that okay? Or should it be > 0.  Noticed a similar issue with a LogNormal test.  Again happy to fix these if you'd like.

In order to keep the PRs small and focussed, I suggest that the test bugfixes be in a different PR.  But happy to add those to this PR if you'd prefer.  Just let me know.

Also updated test.check.