### PR TITLE
Exclude abs in ns forms

### DIFF
--- a/src/kixi/stats/distribution.cljc
+++ b/src/kixi/stats/distribution.cljc
@@ -1,5 +1,5 @@
 (ns kixi.stats.distribution
-  (:refer-clojure :exclude [shuffle rand-int])
+  (:refer-clojure :exclude [shuffle rand-int abs])
   (:require [kixi.stats.math :refer [abs pow log sqrt exp cos sin tan atan PI log-gamma sq floor erf erfcinv] :as m]
             [kixi.stats.protocols :as p :refer [sample-1 sample-n sample-frequencies]]
             [clojure.test.check.random :refer [make-random rand-double rand-long split split-n]]))

--- a/src/kixi/stats/math.cljc
+++ b/src/kixi/stats/math.cljc
@@ -1,5 +1,5 @@
 (ns kixi.stats.math
-  (:refer-clojure :exclude [infinite?]))
+  (:refer-clojure :exclude [infinite? abs]))
 
 (def PI
   #?(:clj Math/PI

--- a/src/kixi/stats/test.cljc
+++ b/src/kixi/stats/test.cljc
@@ -1,4 +1,5 @@
 (ns kixi.stats.test
+  (:refer-clojure :exclude [abs])
   (:require [kixi.stats.distribution :as d]
             [kixi.stats.math :refer [abs clamp pow sq sqrt]]
             [kixi.stats.protocols :as p]

--- a/test/kixi/stats/math_test.cljc
+++ b/test/kixi/stats/math_test.cljc
@@ -1,4 +1,5 @@
 (ns kixi.stats.math-test
+  (:refer-clojure :exclude [abs])
   (:require [kixi.stats.math :as sut :refer [abs]]
             #?@(:cljs
                 [[cljs.test :refer-macros [is deftest]]]

--- a/test/kixi/stats/test_helpers.cljc
+++ b/test/kixi/stats/test_helpers.cljc
@@ -1,4 +1,5 @@
 (ns kixi.stats.test-helpers
+  (:refer-clojure :exclude [abs])
   (:require [clojure.test.check.generators :as gen]
             [kixi.stats.math :refer [abs equal floor ceil]]))
 


### PR DESCRIPTION
Fixes https://github.com/MastodonC/kixi.stats/issues/41

updating ns forms to exclude new clojure.core/abs function. Note that the exclusion does not error or warn if you exclude on an unknown var. This allows this change to safely be used by any Clojure version and does not warn on 1.11.x