### PR TITLE
Fix reflection and auto-boxing warnings

### DIFF
--- a/src/kixi/stats/digest.cljc
+++ b/src/kixi/stats/digest.cljc
@@ -4,7 +4,7 @@
 
 #?(:clj
    (defn ^:no-doc nan->nil [n]
-     (when-not (or (.isNaN n) (.isInfinite n)) n)))
+     (when-not (or (Double/isNaN n) (Double/isInfinite n)) n)))
 
 #?(:clj
    (defn t-digest

--- a/src/kixi/stats/distribution.cljc
+++ b/src/kixi/stats/distribution.cljc
@@ -31,7 +31,7 @@
 
 (defn ^:no-doc btrd-f
   [k]
-  (case k
+  (case (long k)
     0 0.08106146679532726
     1 0.04134069595540929
     2 0.02767792568499834
@@ -220,14 +220,14 @@
 (defn ^:no-doc categorical-sample
   [ks ps n rng]
   (loop [coll '() n n
-         rem 1 rng rng
+         rem 1.0 rng rng
          ks ks ps ps]
     (if (and (seq ks) (> rem 0))
       (let [k (first ks)
             p (first ps)
             x (sample-1 (->Binomial n (/ p rem)) rng)]
         (recur (concat coll (repeat x k)) (- n x)
-               (- rem p) (next-rng rng)
+               (double (- rem p)) (next-rng rng)
                (rest ks) (rest ps)))
       coll)))
 
@@ -449,7 +449,7 @@
       (<= lambda 0.0) 0.0
       (<= lambda 50)
       (let [l (exp (- lambda))]
-        (loop [p 1 k 0 rng rng]
+        (loop [p 1.0 k 0 rng rng]
           (let [p (* p (rand-double rng))]
             (if (> p l)
               (recur p (inc k) (next-rng rng))
@@ -490,14 +490,14 @@
     p/PDiscreteRandomVariable
     (sample-frequencies [_ n rng]
       (loop [coll (transient {}) n n
-             rem 1 rng rng
+             rem 1.0 rng rng
              ks ks ps ps]
         (if (and (seq ks) (pos? rem))
           (let [k (first ks)
                 p (first ps)
                 x (rand-binomial n (/ p rem) rng)]
             (recur (assoc! coll k x) (- n x)
-                   (- rem p) (next-rng rng)
+                   (double (- rem p)) (next-rng rng)
                    (rest ks) (rest ps)))
           (persistent! coll))))
     #?@(:clj (clojure.lang.Seqable
@@ -510,13 +510,13 @@
     p/PRandomVariable
     (sample-1 [_ rng]
       (loop [coll (transient []) n n
-             rem 1 rng rng
+             rem 1.0 rng rng
              ps ps]
         (if (and (seq ps) (pos? rem))
           (let [p (first ps)
                 x (rand-binomial n (/ p rem) rng)]
             (recur (conj! coll x) (- n x)
-                   (- rem p) (next-rng rng)
+                   (double (- rem p)) (next-rng rng)
                    (rest ps)))
           (persistent! coll))))
     (sample-n [this n rng]

--- a/src/kixi/stats/math.cljc
+++ b/src/kixi/stats/math.cljc
@@ -62,7 +62,7 @@
      :cljs (js/Math.floor x)))
 
 (defn round [x]
-  #?(:clj  (Math/round x)
+  #?(:clj  (Math/round (double x))
      :cljs (js/Math.round x)))
 
 (defn equal [x y e]
@@ -187,7 +187,7 @@
   (let [abs-x (abs x)]
     (if (<= abs-x 20)
       (if (>= x 1)
-        (loop [t (dec x) p 1]
+        (loop [t (dec x) p 1.0]
           (if (> t 1.5)
             (recur (dec t) (* p t))
             (/ p (inc (inv-gamma-1pm1 t)))))
@@ -301,9 +301,9 @@
         qap (inc a)
         qam (dec a)
         d (/ 1 (check (- 1 (/ (* x qab) qap))))]
-    (loop [m 1
+    (loop [m 1.0
            h d
-           c 1
+           c 1.0
            d d]
       (let [m2 (* 2 m)
             aa (* m (- b m) (/ x (* (+ qam m2) (+ a m2))))
@@ -312,7 +312,7 @@
             h (* h d c)
             aa (* (- (+ a m)) (+ qab m) (/ x (* (+ a m2) (+ qap m2))))
             d (/ 1 (check (+ 1 (* aa d))))
-            c (check (+ 1 (/ aa c)))
+            c (double (check (+ 1 (/ aa c))))
             del (* d c)
             h (* h del)]
         (if (or (< (abs del) 3e-7)


### PR DESCRIPTION
Just a cleanup of warnings that are displayed when Kixi is loaded with `*warn-on-reflection*` set to true.