### PR TITLE
[perf] Optimize skewness and kurtosis

### DIFF
--- a/src/kixi/stats/core.cljc
+++ b/src/kixi/stats/core.cljc
@@ -182,11 +182,15 @@
   "Estimates the sample skewness of numeric inputs.
   See https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance."
   (fn
-    ([] [0.0 0.0 0.0 0.0])
-    ([[^double c ^double m1 ^double m2 ^double m3 :as acc] e]
+    ([] (double-array 4 0.0))
+    ([^doubles acc e]
      (if (nil? e)
        acc
-       (let [e   (double e)
+       (let [c   (aget acc 0)
+             m1  (aget acc 1)
+             m2  (aget acc 2)
+             m3  (aget acc 3)
+             e   (double e)
              c'  (inc c)
              d   (- e m1)
              dc  (/ d c')
@@ -195,9 +199,16 @@
              m3' (+ m3
                     (/ (* (pow d 3) (- c' 1) (- c' 2)) (sq c'))
                     (* -3 m2 dc))]
-         [c' m1' m2' m3'])))
-    ([[c _ m2 m3]]
-     (let [d (* (pow m2 1.5) (- c 2))]
+         (aset acc 0 c')
+         (aset acc 1 m1')
+         (aset acc 2 m2')
+         (aset acc 3 m3')
+         acc)))
+    ([^doubles acc]
+     (let [c   (aget acc 0)
+           m2  (aget acc 2)
+           m3  (aget acc 3)
+           d (* (pow m2 1.5) (- c 2))]
        (when-not (zero? d)
          (/ (* (sqrt (dec c)) m3 c) d))))))
 
@@ -219,11 +230,16 @@
   See https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance
   and http://www.real-statistics.com/descriptive-statistics/symmetry-skewness-kurtosis."
   (fn
-    ([] [0.0 0.0 0.0 0.0 0.0])
-    ([[^double c ^double m1 ^double m2 ^double m3 ^double m4 :as acc] e]
+    ([] (double-array 5 0.0))
+    ([^doubles acc e]
      (if (nil? e)
        acc
-       (let [e   (double e)
+       (let [c   (aget acc 0)
+             m1  (aget acc 1)
+             m2  (aget acc 2)
+             m3  (aget acc 3)
+             m4  (aget acc 4)
+             e   (double e)
              c'  (inc c)
              d   (- e m1)
              dc  (/ d c')
@@ -237,14 +253,22 @@
                        (pow c' 3))
                     (* 6 m2 (sq dc))
                     (* -4 m3 dc))]
-         [c' m1' m2' m3' m4'])))
-    ([[c _ m2 _ m4]]
-     (when-not (or (zero? m2) (< c 4))
-       (let [v (/ m2 (dec c))]
-         (- (/ (* c (inc c) m4)
-               (* (- c 1) (- c 2) (- c 3) (sq v)))
-            (/ (* 3 (sq (dec c)))
-               (* (- c 2) (- c 3)))))))))
+         (aset acc 0 c')
+         (aset acc 1 m1')
+         (aset acc 2 m2')
+         (aset acc 3 m3')
+         (aset acc 4 m4')
+         acc)))
+    ([^doubles acc]
+     (let [c   (aget acc 0)
+           m2  (aget acc 2)
+           m4  (aget acc 4)]
+       (when-not (or (zero? m2) (< c 4))
+         (let [v (/ m2 (dec c))]
+           (- (/ (* c (inc c) m4)
+                 (* (- c 1) (- c 2) (- c 3) (sq v)))
+              (/ (* 3 (sq (dec c)))
+                 (* (- c 2) (- c 3))))))))))
 
 (def kurtosis
   "Alias for kurtosis-s."


### PR DESCRIPTION
Use mutable double arrays instead of boxed Double tuples to save on:

- allocating tuples
- boxing doubles

In one Metabase, benchmark these changes cut down ~8% allocations. Not a lot, but given this is almost free, I think it's worth considering.

Diffgraph: https://flamebin.dev/ytpYhE